### PR TITLE
Install Or Update Dependabot to support Docker and Gomods

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,30 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    ignore:
-    - dependency-name: "k8s.io/*"
-    - dependency-name: "sigs.k8s.io/*"
-    - dependency-name: "github.com/containernetworking/*"
-    - dependency-name: "github.com/k8snetworkplumbingwg/*"
-      update-types: ["version-update:semver-major", "version-update:semver-minor"] # ignore all except for patch updates
-    - dependency-name: "github.com/vmware/go-ipfix"
-    - dependency-name: "github.com/TomCodeLV/OVSDB-golang-lib"
-    - dependency-name: "github.com/aws/*" # updates are too frequent
-    - dependency-name: "antrea.io/ofnet"
-    - dependency-name: "antrea.io/libOpenflow"
-    - dependency-name: "github.com/ClickHouse/clickhouse-go/v2" # auto-upgrade involves dependency conflicts
-  - package-ecosystem: "github-actions"
-    # Workflow files stored in the default location of `.github/workflows`
-    directory: "/"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  ignore:
+  - dependency-name: k8s.io/*
+  - dependency-name: sigs.k8s.io/*
+  - dependency-name: github.com/containernetworking/*
+  - dependency-name: github.com/k8snetworkplumbingwg/*
+    update-types:
+    - version-update:semver-major
+    - version-update:semver-minor
+  - dependency-name: github.com/vmware/go-ipfix
+  - dependency-name: github.com/TomCodeLV/OVSDB-golang-lib
+  - dependency-name: github.com/aws/*
+  - dependency-name: antrea.io/ofnet
+  - dependency-name: antrea.io/libOpenflow
+  - dependency-name: github.com/ClickHouse/clickhouse-go/v2
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+- package-ecosystem: docker
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION

Enable Dependabot for Docker and GoMod if not already so.
This is to keep our base images, Golang Builder Images, 
and Go Module dependencies up-to-date.

Keeping dependencies up to date is CRITICAL to proactively 
prevent CVEs.

This PR is created by bot.

Signed-off-by: zhuxiaow@google.com
